### PR TITLE
AVX512

### DIFF
--- a/include/zupt_cpuid.h
+++ b/include/zupt_cpuid.h
@@ -12,13 +12,33 @@ typedef struct {
     int has_pclmul;  /* CPUID.01H:ECX[1]  — CLMUL (carry-less multiply) */
     int has_avx2;    /* CPUID.07H:EBX[5]  — AVX2 (256-bit SIMD) */
     int has_sse41;   /* CPUID.01H:ECX[19] — SSE4.1 */
+
+    int has_avx;       /* CPUID.01H:ECX[28]  — AVX */
+    int has_osxsave;   /* CPUID.01H:ECX[27]  — XSAVE/XGETBV enabled by OS */
+
+    int has_avx512f;   /* CPUID.07H:EBX[16]  — AVX-512 Foundation */
+    int has_avx512dq;  /* CPUID.07H:EBX[17]  — AVX-512 Doubleword/Quadword */
+    int has_avx512cd;  /* CPUID.07H:EBX[28]  — AVX-512 Conflict Detection */
+    int has_avx512bw;  /* CPUID.07H:EBX[30]  — AVX-512 Byte/Word */
+    int has_avx512vl;  /* CPUID.07H:EBX[31]  — AVX-512 Vector Length */
+
 } zupt_cpu_features_t;
 
 /*@ assigns f->has_aesni, f->has_pclmul, f->has_avx2, f->has_sse41;
+              f->has_avx, f->has_osxsave,
+              f->has_avx512f, f->has_avx512dq, f->has_avx512cd,
+              f->has_avx512bw, f->has_avx512vl;
   @ ensures f->has_aesni == 0 || f->has_aesni == 1;
   @ ensures f->has_pclmul == 0 || f->has_pclmul == 1;
   @ ensures f->has_avx2 == 0 || f->has_avx2 == 1;
   @ ensures f->has_sse41 == 0 || f->has_sse41 == 1;
+  @ ensures f->has_avx == 0 || f->has_avx == 1;
+  @ ensures f->has_osxsave == 0 || f->has_osxsave == 1;
+  @ ensures f->has_avx512f == 0 || f->has_avx512f == 1;
+  @ ensures f->has_avx512dq == 0 || f->has_avx512dq == 1;
+  @ ensures f->has_avx512cd == 0 || f->has_avx512cd == 1;
+  @ ensures f->has_avx512bw == 0 || f->has_avx512bw == 1;
+  @ ensures f->has_avx512vl == 0 || f->has_avx512vl == 1;  
 */
 void zupt_detect_cpu(zupt_cpu_features_t *f);
 

--- a/src/zupt_cpuid.c
+++ b/src/zupt_cpuid.c
@@ -2,18 +2,14 @@
  * Zupt — CPU Feature Detection
  * Copyright (c) 2026 Cristian Cezar Moisés — MIT License
  *
- * Detects AES-NI, PCLMUL, AVX2, SSE4.1 at runtime.
- * Used to dispatch AES-256-CTR to hardware path when available.
+ * Detects AES-NI, PCLMUL, AVX, AVX2, AVX-512, SSE4.1 at runtime.
+ * Used to dispatch optimized code paths when available.
  */
 #include "zupt_cpuid.h"
 #include <string.h>
 
 /* Global instance */
-zupt_cpu_features_t zupt_cpu = {0, 0, 0, 0};
-
-/* ═══════════════════════════════════════════════════════════════════
- * CPUID intrinsics — platform-specific
- * ═══════════════════════════════════════════════════════════════════ */
+zupt_cpu_features_t zupt_cpu = {0};
 
 #if defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)
   #define ZUPT_HAS_CPUID 1
@@ -25,20 +21,41 @@ zupt_cpu_features_t zupt_cpu = {0, 0, 0, 0};
 
 #if defined(_MSC_VER)
   #include <intrin.h>
+
   static void zupt_cpuid(int leaf, int subleaf, int *eax, int *ebx, int *ecx, int *edx) {
       int regs[4];
       __cpuidex(regs, leaf, subleaf);
-      *eax = regs[0]; *ebx = regs[1]; *ecx = regs[2]; *edx = regs[3];
+      *eax = regs[0];
+      *ebx = regs[1];
+      *ecx = regs[2];
+      *edx = regs[3];
   }
+
+  static uint64_t zupt_xgetbv(unsigned int xcr) {
+      return _xgetbv(xcr);
+  }
+
 #elif defined(__GNUC__) || defined(__clang__)
   #include <cpuid.h>
+
   static void zupt_cpuid(int leaf, int subleaf, int *eax, int *ebx, int *ecx, int *edx) {
       unsigned int a = 0, b = 0, c = 0, d = 0;
       __cpuid_count((unsigned int)leaf, (unsigned int)subleaf, a, b, c, d);
-      *eax = (int)a; *ebx = (int)b; *ecx = (int)c; *edx = (int)d;
+      *eax = (int)a;
+      *ebx = (int)b;
+      *ecx = (int)c;
+      *edx = (int)d;
   }
+
+  static uint64_t zupt_xgetbv(unsigned int xcr) {
+      unsigned int eax, edx;
+      __asm__ __volatile__ (".byte 0x0f, 0x01, 0xd0"
+                            : "=a"(eax), "=d"(edx)
+                            : "c"(xcr));
+      return ((uint64_t)edx << 32) | eax;
+  }
+
 #else
-  /* Inline assembly fallback */
   static void zupt_cpuid(int leaf, int subleaf, int *eax, int *ebx, int *ecx, int *edx) {
       __asm__ __volatile__ (
           "cpuid"
@@ -46,27 +63,86 @@ zupt_cpu_features_t zupt_cpu = {0, 0, 0, 0};
           : "a"(leaf), "c"(subleaf)
       );
   }
+
+  static uint64_t zupt_xgetbv(unsigned int xcr) {
+      unsigned int eax, edx;
+      __asm__ __volatile__ (
+          ".byte 0x0f, 0x01, 0xd0"
+          : "=a"(eax), "=d"(edx)
+          : "c"(xcr)
+      );
+      return ((uint64_t)edx << 32) | eax;
+  }
 #endif
 
 void zupt_detect_cpu(zupt_cpu_features_t *f) {
+    int eax, ebx, ecx, edx;
+    int max_leaf = 0;
+    uint64_t xcr0 = 0;
+    int os_has_avx_state = 0;
+    int os_has_avx512_state = 0;
+
     memset(f, 0, sizeof(*f));
 
-    int eax, ebx, ecx, edx;
-
-    /* Check max supported leaf */
+    /* Maximum supported CPUID leaf */
     zupt_cpuid(0, 0, &eax, &ebx, &ecx, &edx);
-    int max_leaf = eax;
+    max_leaf = eax;
 
     if (max_leaf >= 1) {
         zupt_cpuid(1, 0, &eax, &ebx, &ecx, &edx);
-        f->has_aesni  = (ecx >> 25) & 1;  /* ECX bit 25 */
-        f->has_pclmul = (ecx >>  1) & 1;  /* ECX bit 1  */
-        f->has_sse41  = (ecx >> 19) & 1;  /* ECX bit 19 */
+
+        f->has_aesni   = (ecx >> 25) & 1;
+        f->has_pclmul  = (ecx >>  1) & 1;
+        f->has_sse41   = (ecx >> 19) & 1;
+        f->has_avx     = (ecx >> 28) & 1;
+        f->has_osxsave = (ecx >> 27) & 1;
+
+        /*
+         * For AVX usage, OS must enable XMM and YMM state:
+         * XCR0[1] = XMM state
+         * XCR0[2] = YMM state
+         */
+        if (f->has_osxsave) {
+            xcr0 = zupt_xgetbv(0);
+            os_has_avx_state = ((xcr0 & 0x6) == 0x6);
+        }
+
+        if (!os_has_avx_state) {
+            f->has_avx = 0;
+        }
     }
 
     if (max_leaf >= 7) {
         zupt_cpuid(7, 0, &eax, &ebx, &ecx, &edx);
-        f->has_avx2 = (ebx >> 5) & 1;     /* EBX bit 5  */
+
+        /*
+         * AVX2 requires AVX OS state enabled too.
+         */
+        if (os_has_avx_state) {
+            f->has_avx2 = (ebx >> 5) & 1;
+        }
+
+        /*
+         * For AVX-512 usage, OS must enable:
+         * XCR0[1] = XMM
+         * XCR0[2] = YMM
+         * XCR0[5] = opmask
+         * XCR0[6] = ZMM_hi256
+         * XCR0[7] = Hi16_ZMM
+         *
+         * Required mask = bits 1,2,5,6,7 = 0xE6
+         */
+        if (f->has_osxsave) {
+            os_has_avx512_state = ((xcr0 & 0xE6) == 0xE6);
+        }
+
+        if (os_has_avx512_state) {
+            f->has_avx512f  = (ebx >> 16) & 1;
+            f->has_avx512dq = (ebx >> 17) & 1;
+            f->has_avx512cd = (ebx >> 28) & 1;
+            f->has_avx512bw = (ebx >> 30) & 1;
+            f->has_avx512vl = (ebx >> 31) & 1;
+        }
     }
 }
 
@@ -74,7 +150,7 @@ void zupt_detect_cpu(zupt_cpu_features_t *f) {
 
 void zupt_detect_cpu(zupt_cpu_features_t *f) {
     memset(f, 0, sizeof(*f));
-    /* No AES-NI on ARM/RISC-V/etc — use table fallback */
+    /* No x86 CPUID/XGETBV on ARM/RISC-V/etc */
 }
 
 #endif /* ZUPT_HAS_CPUID */

--- a/src/zupt_main.c
+++ b/src/zupt_main.c
@@ -16,6 +16,10 @@
   #include <termios.h>
 #endif
 
+#if !defined(_WIN32)
+  #include <unistd.h>
+#endif
+
 static void banner(void) {
     fprintf(stderr,
         "Zupt %s - Next-Generation Compression Utility\n"
@@ -33,7 +37,7 @@ static void usage(void) {
         "  zupt list     [OPTIONS] <archive.zupt>\n"
         "  zupt test     [OPTIONS] <archive.zupt>\n"
         "  zupt bench    <files/dirs...>          Compare levels 1-9\n"
-        "  zupt keygen                            Key generation"
+        "  zupt keygen                            Key generation\n"
         "  zupt version\n"
         "  zupt help\n"
         "\n"
@@ -53,7 +57,7 @@ static void usage(void) {
         "Extract/List/Test Options:\n"
         "  -o, --output <DIR>    Output directory (extract only)\n"
         "  -p, --password <PW>   Decryption password\n"
-        "  -pq,--post-quantum    Post-quantum Encryption|Decryption \n"
+        "  -pq,--post-quantum    Post-quantum Encryption|Decryption\n"
         "  -v, --verbose         Verbose output\n"
         "  -t, --threads <N>     Thread count for decompression\n"
         "\n"
@@ -61,14 +65,14 @@ static void usage(void) {
         "\n"
         "Examples:\n"
         "  zupt keygen -o mykey.key                               # Generate keypair\n"
-        "  zupt keygen --pub -o pub.key -k mykey.key              # Export public key\n"
-        "  zupt compress --pq pub.key backup.zupt ~/Documents/    # Encrypt with public key\n" 
+        "  zupt keygen --pub -o pub.key -k mykey.key             # Export public key\n"
+        "  zupt compress --pq pub.key backup.zupt ~/Documents/   # Encrypt with public key\n"
         "  zupt extract --pq mykey.key -o ~/restored/ backup.zupt # Decrypt with private key\n"
-        "  zupt compress backup.zupt ~/Documents/                 # Compress (without password)\n" 
-        "  zupt compress -l 9 -p mysecret secure.zupt data/       # High Compression with password\n"
-        "  zupt list secure.zupt -p mysecret                      # List\n"
-        "  zupt extract -o restored/ -p mysecret secure.zupt      # Extract with password\n"
-        "  zupt bench ~/Documents/                                # Benchmark\n"
+        "  zupt compress backup.zupt ~/Documents/                # Compress (without password)\n"
+        "  zupt compress -l 9 -p mysecret secure.zupt data/      # High Compression with password\n"
+        "  zupt list secure.zupt -p mysecret                     # List\n"
+        "  zupt extract -o restored/ -p mysecret secure.zupt     # Extract with password\n"
+        "  zupt bench ~/Documents/                               # Benchmark\n"
         "\n"
         "Compression: LZ77 (1MB window) + Huffman entropy coding\n"
         "Security:    AES-256-CTR + HMAC-SHA256 (Encrypt-then-MAC)\n"
@@ -106,97 +110,128 @@ static void prompt_password(const char *prompt, char *buf, size_t cap) {
 #endif
 }
 
-static int streq(const char *a, const char *b) { return strcmp(a,b)==0; }
-static int isopt(const char *a) { return a[0]=='-'; }
+static int streq(const char *a, const char *b) { return strcmp(a, b) == 0; }
+static int isopt(const char *a) { return a[0] == '-'; }
+
+static void print_cpu_features(void) {
+    printf("CPU features:\n");
+    printf("  AES-NI     : %s\n", zupt_cpu.has_aesni   ? "yes" : "no");
+    printf("  PCLMUL     : %s\n", zupt_cpu.has_pclmul  ? "yes" : "no");
+    printf("  SSE4.1     : %s\n", zupt_cpu.has_sse41   ? "yes" : "no");
+    printf("  AVX        : %s\n", zupt_cpu.has_avx     ? "yes" : "no");
+    printf("  OSXSAVE    : %s\n", zupt_cpu.has_osxsave ? "yes" : "no");
+    printf("  AVX2       : %s\n", zupt_cpu.has_avx2    ? "yes" : "no");
+    printf("  AVX512F    : %s\n", zupt_cpu.has_avx512f  ? "yes" : "no");
+    printf("  AVX512DQ   : %s\n", zupt_cpu.has_avx512dq ? "yes" : "no");
+    printf("  AVX512CD   : %s\n", zupt_cpu.has_avx512cd ? "yes" : "no");
+    printf("  AVX512BW   : %s\n", zupt_cpu.has_avx512bw ? "yes" : "no");
+    printf("  AVX512VL   : %s\n", zupt_cpu.has_avx512vl ? "yes" : "no");
+}
 
 int main(int argc, char **argv) {
-    /* Detect CPU features (AES-NI, AVX2) at startup */
+    /* Detect CPU features (AES-NI, PCLMUL, SSE4.1, AVX, AVX2, AVX-512) at startup */
     zupt_detect_cpu(&zupt_cpu);
 
     if (argc < 2) { usage(); return 1; }
     const char *cmd = argv[1];
 
-    if (streq(cmd,"help")||streq(cmd,"--help")||streq(cmd,"-h")) { usage(); return 0; }
-    if (streq(cmd,"version")||streq(cmd,"--version")||streq(cmd,"-V")) {
-        printf("zupt %s\nFormat: v%d.%d\nCodec: Zupt-LZ (0x%04X)\n"
-               "Encryption: AES-256-CTR+HMAC-SHA256\nKDF: PBKDF2-SHA256 (%d iter)\n",
-               ZUPT_VERSION_STRING, ZUPT_FORMAT_MAJOR, ZUPT_FORMAT_MINOR,
-               ZUPT_CODEC_ZUPT_LZ, ZUPT_KDF_ITERATIONS);
+    if (streq(cmd, "help") || streq(cmd, "--help") || streq(cmd, "-h")) {
+        usage();
+        return 0;
+    }
+
+    if (streq(cmd, "version") || streq(cmd, "--version") || streq(cmd, "-V")) {
+        printf("zupt %s\n", ZUPT_VERSION_STRING);
+        printf("Format: v%d.%d\n", ZUPT_FORMAT_MAJOR, ZUPT_FORMAT_MINOR);
+        printf("Codec: Zupt-LZ (0x%04X)\n", ZUPT_CODEC_ZUPT_LZ);
+        printf("Encryption: AES-256-CTR+HMAC-SHA256\n");
+        printf("KDF: PBKDF2-SHA256 (%d iter)\n", ZUPT_KDF_ITERATIONS);
+        print_cpu_features();
         return 0;
     }
 
     /* ─── compress ─── */
-    if (streq(cmd,"compress")||streq(cmd,"c")) {
+    if (streq(cmd, "compress") || streq(cmd, "c")) {
         zupt_options_t opts; zupt_default_options(&opts);
         int ai = 2;
-        while (ai<argc && isopt(argv[ai])) {
-            if ((streq(argv[ai],"-l")||streq(argv[ai],"--level"))&&ai+1<argc) {
-                opts.level=atoi(argv[++ai]); if(opts.level<1)opts.level=1; if(opts.level>9)opts.level=9;
-            } else if ((streq(argv[ai],"-b")||streq(argv[ai],"--block"))&&ai+1<argc) {
-                opts.block_size=(uint32_t)atol(argv[++ai]);
-                if(opts.block_size<ZUPT_MIN_BLOCK_SZ)opts.block_size=ZUPT_MIN_BLOCK_SZ;
-                if(opts.block_size>ZUPT_MAX_BLOCK_SZ)opts.block_size=ZUPT_MAX_BLOCK_SZ;
-            } else if (streq(argv[ai],"-s")||streq(argv[ai],"--store")) {
-                opts.codec_id=ZUPT_CODEC_STORE;
-            } else if (streq(argv[ai],"-f")||streq(argv[ai],"--fast")) {
-                opts.codec_id=ZUPT_CODEC_ZUPT_LZ;
-            } else if (streq(argv[ai],"-p")||streq(argv[ai],"--password")) {
-                opts.encrypt=1;
-                if (ai+1<argc && !isopt(argv[ai+1])) {
-                    strncpy(opts.password, argv[++ai], sizeof(opts.password)-1);
+        while (ai < argc && isopt(argv[ai])) {
+            if ((streq(argv[ai], "-l") || streq(argv[ai], "--level")) && ai + 1 < argc) {
+                opts.level = atoi(argv[++ai]);
+                if (opts.level < 1) opts.level = 1;
+                if (opts.level > 9) opts.level = 9;
+            } else if ((streq(argv[ai], "-b") || streq(argv[ai], "--block")) && ai + 1 < argc) {
+                opts.block_size = (uint32_t)atol(argv[++ai]);
+                if (opts.block_size < ZUPT_MIN_BLOCK_SZ) opts.block_size = ZUPT_MIN_BLOCK_SZ;
+                if (opts.block_size > ZUPT_MAX_BLOCK_SZ) opts.block_size = ZUPT_MAX_BLOCK_SZ;
+            } else if (streq(argv[ai], "-s") || streq(argv[ai], "--store")) {
+                opts.codec_id = ZUPT_CODEC_STORE;
+            } else if (streq(argv[ai], "-f") || streq(argv[ai], "--fast")) {
+                opts.codec_id = ZUPT_CODEC_ZUPT_LZ;
+            } else if (streq(argv[ai], "-p") || streq(argv[ai], "--password")) {
+                opts.encrypt = 1;
+                if (ai + 1 < argc && !isopt(argv[ai + 1])) {
+                    strncpy(opts.password, argv[++ai], sizeof(opts.password) - 1);
+                    opts.password[sizeof(opts.password) - 1] = '\0';
                 } else {
                     prompt_password("Password: ", opts.password, sizeof(opts.password));
                     char confirm[256];
                     prompt_password("Confirm:  ", confirm, sizeof(confirm));
-                    if (strcmp(opts.password, confirm)!=0) {
-                        fprintf(stderr, "Error: Passwords do not match.\n"); return 1;
+                    if (strcmp(opts.password, confirm) != 0) {
+                        fprintf(stderr, "Error: Passwords do not match.\n");
+                        return 1;
                     }
                 }
-            } else if (streq(argv[ai],"-v")||streq(argv[ai],"--verbose")) {
-                opts.verbose=1;
-            } else if (streq(argv[ai],"--solid")||streq(argv[ai],"-S")) {
-                opts.solid=1;
-            } else if ((streq(argv[ai],"-t")||streq(argv[ai],"--threads"))&&ai+1<argc) {
-                opts.threads=atoi(argv[++ai]);
-                if(opts.threads<0)opts.threads=0;
-                if(opts.threads>ZUPT_MAX_THREADS)opts.threads=ZUPT_MAX_THREADS;
-            } else if (streq(argv[ai],"--pq")&&ai+1<argc) {
-                opts.pq_mode=1; opts.encrypt=1;
-                strncpy(opts.keyfile, argv[++ai], sizeof(opts.keyfile)-1);
+            } else if (streq(argv[ai], "-v") || streq(argv[ai], "--verbose")) {
+                opts.verbose = 1;
+            } else if (streq(argv[ai], "--solid") || streq(argv[ai], "-S")) {
+                opts.solid = 1;
+            } else if ((streq(argv[ai], "-t") || streq(argv[ai], "--threads")) && ai + 1 < argc) {
+                opts.threads = atoi(argv[++ai]);
+                if (opts.threads < 0) opts.threads = 0;
+                if (opts.threads > ZUPT_MAX_THREADS) opts.threads = ZUPT_MAX_THREADS;
+            } else if (streq(argv[ai], "--pq") && ai + 1 < argc) {
+                opts.pq_mode = 1;
+                opts.encrypt = 1;
+                strncpy(opts.keyfile, argv[++ai], sizeof(opts.keyfile) - 1);
+                opts.keyfile[sizeof(opts.keyfile) - 1] = '\0';
             } else {
-                fprintf(stderr,"Error: Unknown option '%s'\n",argv[ai]); return 1;
+                fprintf(stderr, "Error: Unknown option '%s'\n", argv[ai]);
+                return 1;
             }
             ai++;
         }
-        if (argc-ai<2) {
-            fprintf(stderr,"Error: compress requires <output.zupt> <files/dirs...>\n"); return 1;
+
+        if (argc - ai < 2) {
+            fprintf(stderr, "Error: compress requires <output.zupt> <files/dirs...>\n");
+            return 1;
         }
+
         const char *output = argv[ai++];
 
-        /* Collect files (expand directories recursively) */
         zupt_filelist_t fl; zupt_filelist_init(&fl);
-        for (int i=ai; i<argc; i++)
+        for (int i = ai; i < argc; i++)
             zupt_collect_files(&fl, argv[i], argv[i]);
 
         if (fl.count == 0) {
             fprintf(stderr, "Error: No files found.\n");
-            zupt_filelist_free(&fl); return 1;
+            zupt_filelist_free(&fl);
+            return 1;
         }
 
         banner();
 
-        /* Resolve thread count */
         opts.threads = zupt_resolve_threads(opts.threads);
         if (opts.solid && opts.threads > 1) {
             fprintf(stderr, "  Note: solid mode is single-threaded (cross-file LZ context)\n");
             opts.threads = 1;
         }
 
-        fprintf(stderr, "  Collected %d file(s) for compression%s\n", fl.count,
-                opts.solid ? " (SOLID MODE)" : "");
+        fprintf(stderr, "  Collected %d file(s) for compression%s\n",
+                fl.count, opts.solid ? " (SOLID MODE)" : "");
         if (opts.threads > 1)
             fprintf(stderr, "  Threads: %d\n", opts.threads);
-        if (opts.encrypt) fprintf(stderr, "  Encryption: ENABLED\n");
+        if (opts.encrypt)
+            fprintf(stderr, "  Encryption: ENABLED\n");
         fprintf(stderr, "\n");
 
         zupt_error_t err;
@@ -207,109 +242,165 @@ int main(int argc, char **argv) {
             err = zupt_compress_files(output,
                 (const char**)fl.arc_paths, (const char**)fl.paths, fl.count, &opts);
         }
+
         zupt_filelist_free(&fl);
         zupt_secure_wipe(opts.password, sizeof(opts.password));
-        return err==ZUPT_OK ? 0 : 1;
+        return err == ZUPT_OK ? 0 : 1;
     }
 
     /* ─── extract ─── */
-    if (streq(cmd,"extract")||streq(cmd,"x")) {
+    if (streq(cmd, "extract") || streq(cmd, "x")) {
         zupt_options_t opts; zupt_default_options(&opts);
         const char *outdir = NULL;
         int ai = 2;
-        while (ai<argc && isopt(argv[ai])) {
-            if ((streq(argv[ai],"-o")||streq(argv[ai],"--output"))&&ai+1<argc)
+
+        while (ai < argc && isopt(argv[ai])) {
+            if ((streq(argv[ai], "-o") || streq(argv[ai], "--output")) && ai + 1 < argc) {
                 outdir = argv[++ai];
-            else if (streq(argv[ai],"-p")||streq(argv[ai],"--password")) {
-                opts.encrypt=1;
-                if (ai+1<argc && !isopt(argv[ai+1])) strncpy(opts.password,argv[++ai],sizeof(opts.password)-1);
-                else prompt_password("Password: ", opts.password, sizeof(opts.password));
-            } else if (streq(argv[ai],"-v")||streq(argv[ai],"--verbose")) opts.verbose=1;
-            else if ((streq(argv[ai],"-t")||streq(argv[ai],"--threads"))&&ai+1<argc) {
-                opts.threads=atoi(argv[++ai]);
-                if(opts.threads<0)opts.threads=0;
-                if(opts.threads>ZUPT_MAX_THREADS)opts.threads=ZUPT_MAX_THREADS;
+            } else if (streq(argv[ai], "-p") || streq(argv[ai], "--password")) {
+                opts.encrypt = 1;
+                if (ai + 1 < argc && !isopt(argv[ai + 1])) {
+                    strncpy(opts.password, argv[++ai], sizeof(opts.password) - 1);
+                    opts.password[sizeof(opts.password) - 1] = '\0';
+                } else {
+                    prompt_password("Password: ", opts.password, sizeof(opts.password));
+                }
+            } else if (streq(argv[ai], "-v") || streq(argv[ai], "--verbose")) {
+                opts.verbose = 1;
+            } else if ((streq(argv[ai], "-t") || streq(argv[ai], "--threads")) && ai + 1 < argc) {
+                opts.threads = atoi(argv[++ai]);
+                if (opts.threads < 0) opts.threads = 0;
+                if (opts.threads > ZUPT_MAX_THREADS) opts.threads = ZUPT_MAX_THREADS;
+            } else if (streq(argv[ai], "--pq") && ai + 1 < argc) {
+                opts.pq_mode = 1;
+                opts.encrypt = 1;
+                strncpy(opts.keyfile, argv[++ai], sizeof(opts.keyfile) - 1);
+                opts.keyfile[sizeof(opts.keyfile) - 1] = '\0';
+            } else {
+                fprintf(stderr, "Unknown option '%s'\n", argv[ai]);
+                return 1;
             }
-            else if (streq(argv[ai],"--pq")&&ai+1<argc) {
-                opts.pq_mode=1; opts.encrypt=1;
-                strncpy(opts.keyfile, argv[++ai], sizeof(opts.keyfile)-1);
-            }
-            else { fprintf(stderr,"Unknown option '%s'\n",argv[ai]); return 1; }
             ai++;
         }
-        if (ai>=argc) { fprintf(stderr,"Error: extract requires <archive.zupt>\n"); return 1; }
+
+        if (ai >= argc) {
+            fprintf(stderr, "Error: extract requires <archive.zupt>\n");
+            return 1;
+        }
+
         banner();
         zupt_error_t err = zupt_extract_archive(argv[ai], outdir, &opts);
         zupt_secure_wipe(opts.password, sizeof(opts.password));
-        return err==ZUPT_OK ? 0 : 1;
+        return err == ZUPT_OK ? 0 : 1;
     }
 
     /* ─── list ─── */
-    if (streq(cmd,"list")||streq(cmd,"l")) {
+    if (streq(cmd, "list") || streq(cmd, "l")) {
         zupt_options_t opts; zupt_default_options(&opts);
         int ai = 2;
-        while (ai<argc && isopt(argv[ai])) {
-            if (streq(argv[ai],"-v")||streq(argv[ai],"--verbose")) opts.verbose=1;
-            else if (streq(argv[ai],"-p")||streq(argv[ai],"--password")) {
-                opts.encrypt=1;
-                if (ai+1<argc && !isopt(argv[ai+1])) strncpy(opts.password,argv[++ai],sizeof(opts.password)-1);
-                else prompt_password("Password: ", opts.password, sizeof(opts.password));
+
+        while (ai < argc && isopt(argv[ai])) {
+            if (streq(argv[ai], "-v") || streq(argv[ai], "--verbose")) {
+                opts.verbose = 1;
+            } else if (streq(argv[ai], "-p") || streq(argv[ai], "--password")) {
+                opts.encrypt = 1;
+                if (ai + 1 < argc && !isopt(argv[ai + 1])) {
+                    strncpy(opts.password, argv[++ai], sizeof(opts.password) - 1);
+                    opts.password[sizeof(opts.password) - 1] = '\0';
+                } else {
+                    prompt_password("Password: ", opts.password, sizeof(opts.password));
+                }
+            } else if (streq(argv[ai], "--pq") && ai + 1 < argc) {
+                opts.pq_mode = 1;
+                opts.encrypt = 1;
+                strncpy(opts.keyfile, argv[++ai], sizeof(opts.keyfile) - 1);
+                opts.keyfile[sizeof(opts.keyfile) - 1] = '\0';
+            } else {
+                fprintf(stderr, "Unknown option '%s'\n", argv[ai]);
+                return 1;
             }
-            else if (streq(argv[ai],"--pq")&&ai+1<argc) {
-                opts.pq_mode=1; opts.encrypt=1;
-                strncpy(opts.keyfile, argv[++ai], sizeof(opts.keyfile)-1);
-            }
-            else { fprintf(stderr,"Unknown option '%s'\n",argv[ai]); return 1; }
             ai++;
         }
-        if (ai>=argc) { fprintf(stderr,"Error: list requires <archive.zupt>\n"); return 1; }
+
+        if (ai >= argc) {
+            fprintf(stderr, "Error: list requires <archive.zupt>\n");
+            return 1;
+        }
+
         zupt_error_t err = zupt_list_archive(argv[ai], &opts);
         zupt_secure_wipe(opts.password, sizeof(opts.password));
-        return err==ZUPT_OK ? 0 : 1;
+        return err == ZUPT_OK ? 0 : 1;
     }
 
     /* ─── test ─── */
-    if (streq(cmd,"test")||streq(cmd,"t")) {
+    if (streq(cmd, "test") || streq(cmd, "t")) {
         zupt_options_t opts; zupt_default_options(&opts);
         int ai = 2;
-        while (ai<argc && isopt(argv[ai])) {
-            if (streq(argv[ai],"-v")||streq(argv[ai],"--verbose")) opts.verbose=1;
-            else if (streq(argv[ai],"-p")||streq(argv[ai],"--password")) {
-                opts.encrypt=1;
-                if (ai+1<argc && !isopt(argv[ai+1])) strncpy(opts.password,argv[++ai],sizeof(opts.password)-1);
-                else prompt_password("Password: ", opts.password, sizeof(opts.password));
+
+        while (ai < argc && isopt(argv[ai])) {
+            if (streq(argv[ai], "-v") || streq(argv[ai], "--verbose")) {
+                opts.verbose = 1;
+            } else if (streq(argv[ai], "-p") || streq(argv[ai], "--password")) {
+                opts.encrypt = 1;
+                if (ai + 1 < argc && !isopt(argv[ai + 1])) {
+                    strncpy(opts.password, argv[++ai], sizeof(opts.password) - 1);
+                    opts.password[sizeof(opts.password) - 1] = '\0';
+                } else {
+                    prompt_password("Password: ", opts.password, sizeof(opts.password));
+                }
+            } else if (streq(argv[ai], "--pq") && ai + 1 < argc) {
+                opts.pq_mode = 1;
+                opts.encrypt = 1;
+                strncpy(opts.keyfile, argv[++ai], sizeof(opts.keyfile) - 1);
+                opts.keyfile[sizeof(opts.keyfile) - 1] = '\0';
+            } else {
+                fprintf(stderr, "Unknown option '%s'\n", argv[ai]);
+                return 1;
             }
-            else if (streq(argv[ai],"--pq")&&ai+1<argc) {
-                opts.pq_mode=1; opts.encrypt=1;
-                strncpy(opts.keyfile, argv[++ai], sizeof(opts.keyfile)-1);
-            }
-            else { fprintf(stderr,"Unknown option '%s'\n",argv[ai]); return 1; }
             ai++;
         }
-        if (ai>=argc) { fprintf(stderr,"Error: test requires <archive.zupt>\n"); return 1; }
+
+        if (ai >= argc) {
+            fprintf(stderr, "Error: test requires <archive.zupt>\n");
+            return 1;
+        }
+
         banner();
         zupt_error_t err = zupt_test_archive(argv[ai], &opts);
         zupt_secure_wipe(opts.password, sizeof(opts.password));
-        return err==ZUPT_OK ? 0 : 1;
+        return err == ZUPT_OK ? 0 : 1;
     }
 
     /* ─── bench ─── */
-    if (streq(cmd,"bench")||streq(cmd,"b")) {
+    if (streq(cmd, "bench") || streq(cmd, "b")) {
         int ai = 2;
-        if (ai >= argc) { fprintf(stderr, "Error: bench requires <files/dirs...>\n"); return 1; }
+        if (ai >= argc) {
+            fprintf(stderr, "Error: bench requires <files/dirs...>\n");
+            return 1;
+        }
 
         zupt_filelist_t fl; zupt_filelist_init(&fl);
         for (int i = ai; i < argc; i++)
             zupt_collect_files(&fl, argv[i], argv[i]);
-        if (fl.count == 0) { fprintf(stderr, "No files found.\n"); zupt_filelist_free(&fl); return 1; }
 
-        /* Compute total input size */
+        if (fl.count == 0) {
+            fprintf(stderr, "No files found.\n");
+            zupt_filelist_free(&fl);
+            return 1;
+        }
+
         uint64_t total_in = 0;
         for (int i = 0; i < fl.count; i++) {
             FILE *tf = fopen(fl.paths[i], "rb");
-            if (tf) { fseek(tf, 0, SEEK_END); total_in += (uint64_t)ftell(tf); fclose(tf); }
+            if (tf) {
+                fseek(tf, 0, SEEK_END);
+                total_in += (uint64_t)ftell(tf);
+                fclose(tf);
+            }
         }
-        char isz[32]; zupt_format_size(total_in, isz, sizeof(isz));
+
+        char isz[32];
+        zupt_format_size(total_in, isz, sizeof(isz));
 
         banner();
         fprintf(stderr, "  Benchmarking %d file(s), %s\n\n", fl.count, isz);
@@ -317,7 +408,11 @@ int main(int argc, char **argv) {
         fprintf(stderr, "  ─────────────────────────────────────────────────────────\n");
 
         char tmp_path[256];
+#ifdef _WIN32
+        snprintf(tmp_path, sizeof(tmp_path), "zupt_bench_%d.zupt", (int)time(NULL));
+#else
         snprintf(tmp_path, sizeof(tmp_path), "/tmp/zupt_bench_%d.zupt", (int)getpid());
+#endif
 
         for (int lvl = 1; lvl <= 9; lvl++) {
             zupt_options_t opts; zupt_default_options(&opts);
@@ -334,11 +429,16 @@ int main(int argc, char **argv) {
             if (err == ZUPT_OK) {
                 FILE *zf = fopen(tmp_path, "rb");
                 uint64_t zsize = 0;
-                if (zf) { fseek(zf, 0, SEEK_END); zsize = (uint64_t)ftell(zf); fclose(zf); }
+                if (zf) {
+                    fseek(zf, 0, SEEK_END);
+                    zsize = (uint64_t)ftell(zf);
+                    fclose(zf);
+                }
 
-                char csz[32]; zupt_format_size(zsize, csz, sizeof(csz));
-                double ratio = total_in > 0 ? (double)total_in / (double)zsize : 1.0;
-                double pct = total_in > 0 ? (double)zsize / (double)total_in * 100.0 : 100.0;
+                char csz[32];
+                zupt_format_size(zsize, csz, sizeof(csz));
+                double ratio = total_in > 0 && zsize > 0 ? (double)total_in / (double)zsize : 1.0;
+                double pct   = total_in > 0 ? (double)zsize / (double)total_in * 100.0 : 100.0;
                 double speed = (double)total_in / (double)elapsed / 1048576.0;
 
                 fprintf(stderr, "  %-7d %12s %9.2f:1 %9.1f%% %8.1f MB/s\n",
@@ -346,54 +446,67 @@ int main(int argc, char **argv) {
             } else {
                 fprintf(stderr, "  %-7d %12s\n", lvl, "FAILED");
             }
+
             remove(tmp_path);
         }
+
         fprintf(stderr, "\n");
         zupt_filelist_free(&fl);
         return 0;
     }
 
     /* ─── keygen ─── */
-    if (streq(cmd,"keygen")) {
+    if (streq(cmd, "keygen")) {
         const char *outfile = NULL;
         const char *privfile = NULL;
         int export_pub = 0;
         int ai = 2;
+
         while (ai < argc && isopt(argv[ai])) {
-            if ((streq(argv[ai],"-o")||streq(argv[ai],"--output")) && ai+1 < argc)
+            if ((streq(argv[ai], "-o") || streq(argv[ai], "--output")) && ai + 1 < argc) {
                 outfile = argv[++ai];
-            else if ((streq(argv[ai],"-k")||streq(argv[ai],"--key")) && ai+1 < argc)
+            } else if ((streq(argv[ai], "-k") || streq(argv[ai], "--key")) && ai + 1 < argc) {
                 privfile = argv[++ai];
-            else if (streq(argv[ai],"--pub"))
+            } else if (streq(argv[ai], "--pub")) {
                 export_pub = 1;
-            else { fprintf(stderr, "Unknown option '%s'\n", argv[ai]); return 1; }
+            } else {
+                fprintf(stderr, "Unknown option '%s'\n", argv[ai]);
+                return 1;
+            }
             ai++;
         }
 
         if (!outfile) {
             fprintf(stderr, "Error: keygen requires -o <output_file>\n");
-            fprintf(stderr, "  zupt keygen -o keyfile.key           # Generate keypair\n");
-            fprintf(stderr, "  zupt keygen --pub -o pub.key -k priv.key  # Export public key\n");
+            fprintf(stderr, "  zupt keygen -o keyfile.key                # Generate keypair\n");
+            fprintf(stderr, "  zupt keygen --pub -o pub.key -k priv.key # Export public key\n");
             return 1;
         }
 
         banner();
         if (export_pub) {
-            if (!privfile) { fprintf(stderr, "Error: --pub requires -k <private_keyfile>\n"); return 1; }
+            if (!privfile) {
+                fprintf(stderr, "Error: --pub requires -k <private_keyfile>\n");
+                return 1;
+            }
+
             fprintf(stderr, "  Exporting public key from: %s\n", privfile);
             if (zupt_hybrid_export_pubkey(privfile, outfile) != 0) {
-                fprintf(stderr, "Error: Failed to export public key.\n"); return 1;
+                fprintf(stderr, "Error: Failed to export public key.\n");
+                return 1;
             }
             fprintf(stderr, "  Public key written to: %s\n", outfile);
         } else {
             fprintf(stderr, "  Generating ML-KEM-768 + X25519 keypair...\n");
             if (zupt_hybrid_keygen(outfile) != 0) {
-                fprintf(stderr, "Error: Key generation failed.\n"); return 1;
+                fprintf(stderr, "Error: Key generation failed.\n");
+                return 1;
             }
             fprintf(stderr, "  Private key written to: %s\n", outfile);
             fprintf(stderr, "  SECURITY: Keep this file secret. Back it up securely.\n");
             fprintf(stderr, "  To export public key: zupt keygen --pub -o pub.key -k %s\n", outfile);
         }
+
         return 0;
     }
 


### PR DESCRIPTION
See if this makes sense and aligns with what we discussed.

Tested in 11th Gen Intel
```
 ./zupt version
zupt 1.5.0
Format: v1.4
Codec: Zupt-LZ (0x0008)
Encryption: AES-256-CTR+HMAC-SHA256
KDF: PBKDF2-SHA256 (600000 iter)
CPU features:
  AES-NI     : yes
  PCLMUL     : yes
  SSE4.1     : yes
  AVX        : yes
  OSXSAVE    : yes
  AVX2       : yes
  AVX512F    : yes
  AVX512DQ   : yes
  AVX512CD   : yes
  AVX512BW   : yes
  AVX512VL   : yes
```

Tested in Intel(R) Core(TM) i7-8550U
```
./zupt version
zupt 1.5.0
Format: v1.4
Codec: Zupt-LZ (0x0008)
Encryption: AES-256-CTR+HMAC-SHA256
KDF: PBKDF2-SHA256 (600000 iter)
CPU features:
  AES-NI     : yes
  PCLMUL     : yes
  SSE4.1     : yes
  AVX        : yes
  OSXSAVE    : yes
  AVX2       : yes
  AVX512F    : no
  AVX512DQ   : no
  AVX512CD   : no
  AVX512BW   : no
  AVX512VL   : no
```